### PR TITLE
changes in return statement of evaluate function

### DIFF
--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -247,7 +247,6 @@ def evaluate(args, model, tokenizer, prefix=""):
     # Loop to handle MNLI double evaluation (matched, mis-matched)
     eval_output_dir = args.output_dir
 
-    results = {}
     eval_dataset = load_and_cache_examples(args, tokenizer, evaluate=True)
 
     if not os.path.exists(eval_output_dir) and args.local_rank in [-1, 0]:
@@ -289,7 +288,7 @@ def evaluate(args, model, tokenizer, prefix=""):
             logger.info("  %s = %s", key, str(result[key]))
             writer.write("%s = %s\n" % (key, str(result[key])))
 
-    return results
+    return result
 
 
 def main():


### PR DESCRIPTION
changed `results` to `result` and removed `results` dict defined previously in `evaluate` func